### PR TITLE
Fix absolute paths to system libraries in CMake exported targets.

### DIFF
--- a/recipe/build_chrono.sh
+++ b/recipe/build_chrono.sh
@@ -37,3 +37,11 @@ cmake ${CMAKE_ARGS} \
 # gcc gets out of memory
 cmake --build build -j${CPU_COUNT}
 cmake --install build
+
+# Fix absolute paths to system libraries in CMake exported targets
+if [[ "${target_platform}" == linux-* ]]; then
+    find ${PREFIX} -name "*.cmake" -type f -exec \
+        sed -i 's|/[^;]*libpthread\.so|pthread|g' {} +
+    find ${PREFIX} -name "*.cmake" -type f -exec \
+        sed -i 's|/[^;]*librt\.so|rt|g' {} +
+fi

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 context:
   name: chrono
   version: 9.0.1
-  build: 3
+  build: 4
   sha256: 86da726ed3e3bacf682666b21d9c95dc87746b026dbafc722051a3202b822d39
 
 recipe:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

`chrono`'s `.cmake` file was incorrectly providing absolute paths to the build system's `libpthread` and `librt` instead of mere dependency upon these libraries.  This broke builds of projects linking with `chrono` on Linux.